### PR TITLE
Saner handling of curve names

### DIFF
--- a/src/lib/curves.ts
+++ b/src/lib/curves.ts
@@ -1,0 +1,25 @@
+export type CurveP256 = "p256" | "P-256"
+export type CurveEd25519 = "Ed25519" | "ed25519"
+export type NSupportedCurves = CurveP256 | CurveEd25519;
+
+export const isP256 = (curve: NSupportedCurves): curve is CurveP256 => {
+  return curve === "p256" || curve === "P-256";
+}
+
+export const isEd25519 = (curve: NSupportedCurves): curve is CurveEd25519 => {
+  return curve === "Ed25519" || curve === "ed25519";
+}
+
+export function curveName<T extends NSupportedCurves>(curve: T, format: "jwk" | "elliptic"): NSupportedCurves {
+  if (curve === "p256" || curve === "P-256") {
+    if (format === "elliptic") return "p256"
+    if (format === "jwk") return "P-256"
+  }
+
+  if (curve === "Ed25519" || curve === "ed25519") {
+    if (format === "elliptic") return "ed25519"
+    if (format === "jwk") return "Ed25519"
+  }
+
+  throw new Error(`Unsupported curve: ${curve}`)
+}

--- a/src/types/dids.ts
+++ b/src/types/dids.ts
@@ -1,3 +1,5 @@
+import { NSupportedCurves } from "@/lib/curves";
+
 export const verificationRelationships = [
   "authentication",
   "assertionMethod",
@@ -20,7 +22,7 @@ export type UsageFormat<Type extends Representation> = {
 
 export type EmbeddedType = {
   controller?: string;
-  curve: SupportedCurves;
+  curve: NSupportedCurves;
   keyMaterial: Uint8Array;
   format: KeyFormat;
   usage: UsageFormat<Representation>;


### PR DESCRIPTION
Create abstraction for curve names, as they differ between libraries. This makes it much easier to
1) Write code involving curve names, as you don't need to think of what format goes where
2) Extension for new curves (e.g., `x25519`) becomes way less fiddly